### PR TITLE
add and enable zumapro PIXEL_AIDL_AUDIO_HAL release flag

### DIFF
--- a/flag_declarations/RELEASE_PIXEL_AIDL_AUDIO_HAL.textproto
+++ b/flag_declarations/RELEASE_PIXEL_AIDL_AUDIO_HAL.textproto
@@ -1,0 +1,8 @@
+name: "RELEASE_PIXEL_AIDL_AUDIO_HAL"
+namespace: "android_UNKNOWN"
+description: "use AIDL audio HAL"
+value: {
+  bool_value: false
+}
+workflow: LAUNCH
+containers: "vendor"

--- a/flag_values/ap3a/RELEASE_PIXEL_AIDL_AUDIO_HAL.textproto
+++ b/flag_values/ap3a/RELEASE_PIXEL_AIDL_AUDIO_HAL.textproto
@@ -1,0 +1,4 @@
+name: "RELEASE_PIXEL_AIDL_AUDIO_HAL"
+value: {
+  bool_value: true
+}


### PR DESCRIPTION
These changes fix audio HAL configuration on 9th generation Pixel devices.

Part of a changelist:
https://github.com/GrapheneOS/vendor_state/pull/90
https://github.com/GrapheneOS/adevtool/pull/160