### PR TITLE
don't enable migrate_clocks_to_blueprint and communal_hub SystemUI flags

### DIFF
--- a/aconfig/ap4a/com.android.systemui/communal_hub_flag_values.textproto
+++ b/aconfig/ap4a/com.android.systemui/communal_hub_flag_values.textproto
@@ -1,6 +1,0 @@
-flag_value {
-  package: "com.android.systemui"
-  name: "communal_hub"
-  state: ENABLED
-  permission: READ_ONLY
-}

--- a/aconfig/ap4a/com.android.systemui/migrate_clocks_to_blueprint_flag_values.textproto
+++ b/aconfig/ap4a/com.android.systemui/migrate_clocks_to_blueprint_flag_values.textproto
@@ -1,6 +1,0 @@
-flag_value {
-  package: "com.android.systemui"
-  name: "migrate_clocks_to_blueprint"
-  state: ENABLED
-  permission: READ_ONLY
-}


### PR DESCRIPTION
Enabling the migrate_clocks_to_blueprint flag leads to lockscreen layout issues:
https://github.com/GrapheneOS/os-issue-tracker/issues/4486 
https://github.com/GrapheneOS/os-issue-tracker/issues/4491

communal_hub flag (lockscreen widgets) depends on the migrate_clocks_to_blueprint flag.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/4486 
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/4491