### PR TITLE
[temporary] raise RELEASE_PLATFORM_SECURITY_PATCH to 2025-01-01

### DIFF
--- a/flag_values/ap4a/RELEASE_PLATFORM_SECURITY_PATCH.textproto
+++ b/flag_values/ap4a/RELEASE_PLATFORM_SECURITY_PATCH.textproto
@@ -1,4 +1,4 @@
 name: "RELEASE_PLATFORM_SECURITY_PATCH"
 value: {
-  string_value: "2024-12-05"
+  string_value: "2025-01-01"
 }


### PR DESCRIPTION
Part of a changelist:
https://github.com/GrapheneOS/platform_frameworks_base/pull/103
https://github.com/GrapheneOS/platform_frameworks_native/pull/26
https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/320

external/giflib, packages/modules/Connectivity and packages/services/Telephony `android-security-15.0.0_r4` patches are already included in 15 QPR1.