### PR TITLE
[temporary] raise RELEASE_PLATFORM_SECURITY_PATCH to 2025-02-01

### DIFF
--- a/flag_values/ap4a/RELEASE_PLATFORM_SECURITY_PATCH.textproto
+++ b/flag_values/ap4a/RELEASE_PLATFORM_SECURITY_PATCH.textproto
@@ -1,4 +1,4 @@
 name: "RELEASE_PLATFORM_SECURITY_PATCH"
 value: {
-  string_value: "2025-01-05"
+  string_value: "2025-02-01"
 }


### PR DESCRIPTION
Part of a changelist:
https://github.com/GrapheneOS/platform_external_conscrypt/pull/5
https://github.com/GrapheneOS/platform_frameworks_base/pull/122
https://github.com/GrapheneOS/platform_libcore/pull/20
https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/327
https://github.com/GrapheneOS/platform_packages_modules_Bluetooth/pull/50
https://github.com/GrapheneOS/platform_packages_services_Telecomm/pull/14
https://github.com/GrapheneOS/platform_system_core/pull/32