### PR TITLE
[temporary] raise RELEASE_PLATFORM_SECURITY_PATCH to 2025-03-01

### DIFF
--- a/aconfig/ap4a/com.android.bluetooth.flags/use_encrypt_req_for_av_flag_values.textproto
+++ b/aconfig/ap4a/com.android.bluetooth.flags/use_encrypt_req_for_av_flag_values.textproto
@@ -1,0 +1,6 @@
+flag_value {
+  package: "com.android.bluetooth.flags"
+  name: "use_encrypt_req_for_av"
+  state: ENABLED
+  permission: READ_ONLY
+}

--- a/flag_values/ap4a/RELEASE_PLATFORM_SECURITY_PATCH.textproto
+++ b/flag_values/ap4a/RELEASE_PLATFORM_SECURITY_PATCH.textproto
@@ -1,5 +1,5 @@
 name: "RELEASE_PLATFORM_SECURITY_PATCH"
 value: {
-  string_value: "2025-02-05"
+  string_value: "2025-03-01"
 }
 


### PR DESCRIPTION
Part of a changelist:
https://github.com/GrapheneOS/platform_external_dng_sdk/pull/1
https://github.com/GrapheneOS/platform_frameworks_base/pull/132
https://github.com/GrapheneOS/platform_frameworks_native/pull/29
https://github.com/GrapheneOS/platform_packages_providers_DownloadProvider/pull/11
https://github.com/GrapheneOS/platform_packages_services_Telecomm/pull/17

https://github.com/GrapheneOS/platform_manifest/pull/68
https://github.com/GrapheneOS/script/pull/88