### PR TITLE
re-enable terminal_gui_support flag

### DIFF
--- a/aconfig/bp3a/com.android.system.virtualmachine.flags/terminal_gui_support_flag_values.textproto
+++ b/aconfig/bp3a/com.android.system.virtualmachine.flags/terminal_gui_support_flag_values.textproto
@@ -1,0 +1,6 @@
+flag_value {
+  package: "com.android.system.virtualmachine.flags"
+  name: "terminal_gui_support"
+  state: ENABLED
+  permission: READ_ONLY
+}


### PR DESCRIPTION
terminal_gui_support support flag no longer causes surfaceflinger crashes.