### PR TITLE
Revert "don't enable the broken new_customization_picker_ui flag"

### DIFF
--- a/aconfig/bp3a/com.android.systemui.shared/new_customization_picker_ui_flag_values.textproto
+++ b/aconfig/bp3a/com.android.systemui.shared/new_customization_picker_ui_flag_values.textproto
@@ -1,0 +1,6 @@
+flag_value {
+  package: "com.android.systemui.shared"
+  name: "new_customization_picker_ui"
+  state: ENABLED
+  permission: READ_ONLY
+}


### PR DESCRIPTION
This reverts commit 7cbc4e87b4065c29e056a67bf26e8b3226399820.