### PR TITLE
do not enable the buggy no_sbnholder flag

### DIFF
--- a/aconfig/bp4a/android.app/no_sbnholder_flag_values.textproto
+++ b/aconfig/bp4a/android.app/no_sbnholder_flag_values.textproto
@@ -1,6 +1,0 @@
-flag_value {
-  package: "android.app"
-  name: "no_sbnholder"
-  state: ENABLED
-  permission: READ_ONLY
-}


### PR DESCRIPTION
This flag disables the IStatusBarNotificationHolder optimization which allows to transfer large notification objects over binder without running out of binder transaction buffer space.

Closes https://github.com/GrapheneOS/os-issue-tracker/issues/7733