### PR TITLE
enable photopicker in com.android.wallpaper

### DIFF
--- a/aconfig/cp2a/com.android.wallpaper/enable_android_photopicker_flag_values.textproto
+++ b/aconfig/cp2a/com.android.wallpaper/enable_android_photopicker_flag_values.textproto
@@ -1,0 +1,6 @@
+flag_value {
+  package: "com.android.wallpaper"
+  name: "enable_android_photopicker"
+  state: ENABLED
+  permission: READ_ONLY
+}


### PR DESCRIPTION
Closes: https://github.com/GrapheneOS/os-issue-tracker/issues/8071