### PR TITLE
enable telecom register_bluetooth_receiver_for_all_users flag

### DIFF
--- a/aconfig/cp2a/com.android.internal.telecom.flags/register_bluetooth_receiver_for_all_users_flag_values.textproto
+++ b/aconfig/cp2a/com.android.internal.telecom.flags/register_bluetooth_receiver_for_all_users_flag_values.textproto
@@ -1,0 +1,6 @@
+flag_value {
+  package: "com.android.internal.telecom.flags"
+  name: "register_bluetooth_receiver_for_all_users"
+  state: ENABLED
+  permission: READ_ONLY
+}


### PR DESCRIPTION
Closes https://github.com/GrapheneOS/os-issue-tracker/issues/8132

Note that this flag is on in CP31.260522.006

In secondary users, Telecom was not receiving Bluetooth headset connection broadcasts, so calls only exposed speaker/phone routing even when an HFP headset was connected. The receiver was registered only for the system user unless this flag was enabled, which missed broadcasts sent from the secondary user's Bluetooth process.

Test: Telecom calls using SIM in secondary users now have Bluetooth headset support. Dialer exposes
options between Bluetooth headset, Speaker, and Phone for the incallui